### PR TITLE
plotly dash app example

### DIFF
--- a/dash/Dockerfile
+++ b/dash/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY dash_app.py .
+CMD ["python", "dash_app.py"]

--- a/dash/dash_app.py
+++ b/dash/dash_app.py
@@ -1,0 +1,33 @@
+import os
+import dash
+from dash import html, dcc
+import plotly.express as px
+import sqlalchemy
+import pandas as pd
+
+def fetch_data():
+    db_url = (
+        f"postgresql://{os.environ.get('DASH_DB_USER', 'user')}:"
+        f"{os.environ.get('DASH_DB_PASSWORD', 'password')}@"
+        f"{os.environ.get('DASH_DB_HOST', 'localhost')}:"
+        f"{os.environ.get('DASH_DB_PORT', '5432')}/"
+        f"{os.environ.get('DASH_DB_NAME', 'exampledb')}"
+    )
+    engine = sqlalchemy.create_engine(db_url)
+    query = "SELECT id, value FROM sample_table LIMIT 10;"
+    df = pd.read_sql(query, engine)
+    engine.dispose()
+    return df
+
+app = dash.Dash(__name__)
+
+df = fetch_data()
+fig = px.bar(df, x="id", y="value", title="Sample Data from PostgreSQL")
+
+app.layout = html.Div([
+    html.H1("PostgreSQL Data Plot"),
+    dcc.Graph(figure=fig)
+])
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8050, debug=True)

--- a/dash/requirements.txt
+++ b/dash/requirements.txt
@@ -1,0 +1,6 @@
+dash
+plotly
+numpy
+pandas
+sqlalchemy
+psycopg2-binary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-db}
     volumes:
       - ./create_database_schema.sql:/docker-entrypoint-initdb.d/create_database_schema.sql:ro
+      - ./init_dash_sample.sql:/docker-entrypoint-initdb.d/init_dash_sample.sql:ro
       - ./ozi_pgdata:/var/lib/postgresql/data
     ports:
       - "5432:5432"
@@ -49,6 +50,26 @@ services:
       OZI_DATABASE_PASSWORD: ${POSTGRES_OZI_PASSWORD:-password}
     volumes:
       - ./etl/logs:/app/etl/logs
+    networks:
+      - ozi_network
+
+  dash-app:
+    build:
+      context: ./dash
+      dockerfile: Dockerfile
+    container_name: dash_app
+    restart: always
+    depends_on:
+      ozi-postgres:
+        condition: service_healthy
+    environment:
+      DASH_DB_HOST: ozi-postgres
+      DASH_DB_PORT: 5432
+      DASH_DB_NAME: ${POSTGRES_DB:-db}
+      DASH_DB_USER: ${POSTGRES_USER:-postgres}
+      DASH_DB_PASSWORD: ${POSTGRES_PASSWORD:-password}
+    ports:
+      - "8050:8050"
     networks:
       - ozi_network
 

--- a/init_dash_sample.sql
+++ b/init_dash_sample.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS sample_table (
+    id SERIAL PRIMARY KEY,
+    value INTEGER NOT NULL
+);
+
+INSERT INTO sample_table (value) VALUES (10), (20), (30), (40), (50);


### PR DESCRIPTION
# Do not merge

this adds a plotly redash app which raises a web server and publishes a plot there like this
<img width="1268" height="691" alt="image" src="https://github.com/user-attachments/assets/ff206634-2141-4cbf-925e-3e32f573a7dc" />

The plot is not static, it's interactive and doesn't have administration overhead of Redash, currently it reads a sample table which is created by additional init script for the DB